### PR TITLE
SNOK-1811-Plc-snap7-library-does-not-fetch-code-interface-date-timestamp-information-of-plc-memory-block

### DIFF
--- a/snap7-full-1.4.2/src/core/s7_micro_client.h
+++ b/snap7-full-1.4.2/src/core/s7_micro_client.h
@@ -27,6 +27,7 @@
 #define s7_micro_client_h
 //---------------------------------------------------------------------------
 #include "s7_peer.h"
+#include <cstdio>
 //---------------------------------------------------------------------------
 
 const longword errCliMask                   = 0xFFF00000;
@@ -112,6 +113,11 @@ typedef struct {
    // Chars info
    char CodeDate[11];
    char IntfDate[11];
+
+    // Chars info (millisecond-accurate)
+   char CodeDateTime[25];  // Format: "YYYY/MM/DD HH:MM:SS.mmm"
+   char IntfDateTime[25];
+
    char Author[9];
    char Family[9];
    char Header[9];
@@ -249,6 +255,7 @@ class TSnap7MicroClient: public TSnap7Peer
 {
 private:
     void FillTime(word SiemensTime, char *PTime);
+    void FillDateTime(word SiemensDay, u_int SiemensMs, char *PTime);
     byte BCDtoByte(byte B);
     byte WordToBCD(word Value);
     int opReadArea();


### PR DESCRIPTION
**[SNOK-1811](https://securenok.atlassian.net/browse/SNOK-1811)-Plc-snap7-library-does-not-fetch-code-interface-date-timestamp-information-of-plc-memory-block**

- added support to fetch the timestamp information for the `CodeDateTime` and `IntfDateTime` of PLC memory blocks
  - The library will return two new fields, `CodeDateTime` and `IntfDateTime`, in the structs `TS7BlockInfo`  and  `PS7BlockInfo`, which will contain the full timestamp information of the memory blocks.
- This solves the issue mentioned in https://github.com/Securenok/snap7/issues/1

[SNOK-1811]: https://securenok.atlassian.net/browse/SNOK-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ